### PR TITLE
Support TGS format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pillow
 moviepy
 imageio
 imageio-ffmpeg
+lottie
+CairoSVG


### PR DESCRIPTION
Implements https://github.com/rainyskye/signal-tgstickers/issues/4

Requires cairo libs for lottie webp support.